### PR TITLE
Added file.close() after dump

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -2162,7 +2162,8 @@
     "file = open('random_forest_regression_model.pkl', 'wb')\n",
     "\n",
     "# dump information to that file\n",
-    "pickle.dump(rf_random, file)"
+    "pickle.dump(rf_random, file)",
+    "file.close()"
    ]
   },
   {


### PR DESCRIPTION
If you dont add file.close() after dumping the pickle file, it wont close the file and the pickle file would still be 0 bytes.